### PR TITLE
Pass $(CC) to make with quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ clobber: clean
 .PHONY: clobber
 
 cli: ./include/rule_type.h src/parser.c src/dialect.c $(SRC_FILES) src/Makefile
-	cd src; $(MAKE) CC=$(CC) $@
+	cd src; $(MAKE) CC="$(CC)" $@
 .PHONY: libs
 
 libs: ./include/rule_type.h src/parser.c src/dialect.c $(SRC_FILES) src/Makefile
-	cd src; $(MAKE) CC=$(CC) $@
+	cd src; $(MAKE) CC="$(CC)" $@
 .PHONY: libs
 
 .run: cli $(GHERKIN) $(GOOD_FEATURE_FILES)


### PR DESCRIPTION
To allow use path to compiler with spaces. For example: "ccache gcc".